### PR TITLE
Fix error where punctuation in the middle of text does not advance index 

### DIFF
--- a/lib/abcdable.rb
+++ b/lib/abcdable.rb
@@ -6,7 +6,7 @@ module Abcdable
 
   def alphabet_index
     alphabet_with_index = {}
-    alphabet.to_enum.with_index do |letter, index|
+    alphabet.each.with_index do |letter, index|
       alphabet_with_index[letter] = index
     end
     alphabet_with_index

--- a/lib/decryption.rb
+++ b/lib/decryption.rb
@@ -1,14 +1,8 @@
-require_relative "abcdable"
 require_relative "shift"
-require 'pry'
 
 class Decryption < Shift
 
-  include Defaultable
-  include Abcdable
-
-  attr_reader :indexes,
-              :decrypted_message
+  attr_reader :decrypted_message
 
   def initialize(text, key = randomize, date = today)
     @text = super

--- a/lib/decryption.rb
+++ b/lib/decryption.rb
@@ -15,7 +15,6 @@ class Decryption < Shift
     @key = super
     @date = super
     @shifts = super
-    @indexes = set_indexes
     @decrypted_message = [].join
   end
 
@@ -50,6 +49,7 @@ class Decryption < Shift
     raw_text = @text.split("")
     raw_text.each.with_index do |letter, index|
       if !alphabet.include?(letter)
+        advance_symbol_index(index)
         @decrypted_message << letter
       else
         decrypt_letter(index, letter)

--- a/lib/decryption.rb
+++ b/lib/decryption.rb
@@ -1,5 +1,6 @@
 require_relative "abcdable"
 require_relative "shift"
+require 'pry'
 
 class Decryption < Shift
 
@@ -46,8 +47,8 @@ class Decryption < Shift
   end
 
   def decrypt_message
-    raw_text = @text.split("").to_enum
-    raw_text.with_index do |letter, index|
+    raw_text = @text.split("")
+    raw_text.each.with_index do |letter, index|
       if !alphabet.include?(letter)
         @decrypted_message << letter
       else

--- a/lib/encryption.rb
+++ b/lib/encryption.rb
@@ -1,14 +1,8 @@
-require_relative "abcdable"
-require_relative "defaultable"
 require_relative "shift"
 
 class Encryption < Shift
 
-  include Abcdable
-  include Defaultable
-
-  attr_reader :indexes,
-              :encrypted_message
+  attr_reader :encrypted_message
 
   def initialize(text, key = randomize, date = today)
     @text = super

--- a/lib/encryption.rb
+++ b/lib/encryption.rb
@@ -15,7 +15,6 @@ class Encryption < Shift
     @key = super
     @date = super
     @shifts = super
-    @indexes = set_indexes
     @encrypted_message = [].join
   end
 
@@ -38,24 +37,12 @@ class Encryption < Shift
     end
   end
 
-  def advance_symbol_index(index)
-    if index == @indexes[:a]
-      @indexes[:a] += 4
-    elsif index == @indexes[:b]
-      @indexes[:b] += 4
-    elsif index == @indexes[:c]
-      @indexes[:c] += 4
-    elsif index == @indexes[:d]
-      @indexes[:d] += 4
-    end
-  end
-
   def encrypt_message
     raw_text = @text.split("")
     raw_text.each.with_index do |letter, index|
       if !alphabet.include?(letter)
-        @encrypted_message << letter
         advance_symbol_index(index)
+        @encrypted_message << letter
       else
         encrypt_letter(index, letter)
       end

--- a/lib/encryption.rb
+++ b/lib/encryption.rb
@@ -38,11 +38,24 @@ class Encryption < Shift
     end
   end
 
+  def advance_symbol_index(index)
+    if index == @indexes[:a]
+      @indexes[:a] += 4
+    elsif index == @indexes[:b]
+      @indexes[:b] += 4
+    elsif index == @indexes[:c]
+      @indexes[:c] += 4
+    elsif index == @indexes[:d]
+      @indexes[:d] += 4
+    end
+  end
+
   def encrypt_message
-    raw_text = @text.split("").to_enum
-    raw_text.with_index do |letter, index|
+    raw_text = @text.split("")
+    raw_text.each.with_index do |letter, index|
       if !alphabet.include?(letter)
         @encrypted_message << letter
+        advance_symbol_index(index)
       else
         encrypt_letter(index, letter)
       end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -10,12 +10,6 @@ class Enigma
               :key,
               :date
 
-  def initialize
-    @message = nil
-    @key = nil
-    @date = nil
-  end
-
   def encrypt(text, key = randomize, date = today)
     create_encryption(text, key, date)
     data = Hash.new

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -3,13 +3,15 @@ require_relative "abcdable"
 class Shift
 
   include Defaultable
-  include Abcdable 
+  include Abcdable
 
   attr_reader :text,
               :key,
               :date,
               :date_squared,
-              :last_four
+              :last_four,
+              :shifts,
+              :indexes
 
   def initialize(text, key = randomize, date = today)
     @text = text.downcase

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,8 +1,9 @@
 require_relative "defaultable"
-
+require_relative "abcdable"
 class Shift
 
   include Defaultable
+  include Abcdable 
 
   attr_reader :text,
               :key,
@@ -17,6 +18,7 @@ class Shift
     @date_squared = square_date(date).to_s
     @last_four = last_four(date)
     @shifts = get_shifts
+    @indexes = set_indexes
   end
 
   def square_date(date)
@@ -47,6 +49,18 @@ class Shift
     key_offset_pairs = keys.zip(offsets)
     @shifts = key_offset_pairs.map do |pair|
       pair.sum
+    end
+  end
+
+  def advance_symbol_index(index)
+    if index == @indexes[:a]
+      @indexes[:a] += 4
+    elsif index == @indexes[:b]
+      @indexes[:b] += 4
+    elsif index == @indexes[:c]
+      @indexes[:c] += 4
+    elsif index == @indexes[:d]
+      @indexes[:d] += 4
     end
   end
 

--- a/lib/shift.rb
+++ b/lib/shift.rb
@@ -1,5 +1,6 @@
 require_relative "defaultable"
 require_relative "abcdable"
+
 class Shift
 
   include Defaultable

--- a/test/decryption_test.rb
+++ b/test/decryption_test.rb
@@ -124,7 +124,18 @@ class DecryptionTest < Minitest::Test
   end
 
   def test_it_can_decrypt_with_punctuation_between_letters
-    decrypt = Decryption.new(" dy,hqrt?", "80304", "040387")
-    assert_equal "sup, girl?", decrypt.decrypted_message
+    decrypt = Decryption.new("keder,sprrdx!", "02715", "040895")
+    decrypt.decrypt_message 
+    assert_equal "hello, world!", decrypt.decrypted_message
+  end
+
+  def test_it_can_advance_symbol_index_with_punctuation
+    decrypt = Decryption.new(".....", "02715", "040895")
+    decrypt.decrypt_message
+    assert_equal 8, decrypt.indexes[:a]
+    assert_equal 5, decrypt.indexes[:b]
+    assert_equal 6, decrypt.indexes[:c]
+    assert_equal 7, decrypt.indexes[:d]
+    assert_equal ".....", decrypt.decrypted_message
   end
 end

--- a/test/decryption_test.rb
+++ b/test/decryption_test.rb
@@ -122,4 +122,9 @@ class DecryptionTest < Minitest::Test
     assert_equal "c", decrypt.decrypted_message
     assert_equal ({:a => 4, :b => 1, :c => 2, :d => 3}), decrypt.indexes
   end
+
+  def test_it_can_decrypt_with_punctuation_between_letters
+    decrypt = Decryption.new(" dy,hqrt?", "80304", "040387")
+    assert_equal "sup, girl?", decrypt.decrypted_message
+  end
 end

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -129,10 +129,14 @@ class EncryptionTest < Minitest::Test
     assert_equal ({:a => 4, :b => 1, :c => 2, :d => 3}), encrypt.indexes
   end
 
-  def test_it_can_advance_symbol_index
-    encrypt = Encryption.new("Hello, World", "02715", "040895")
-    encrypt.advance_symbol_index(6)
-    assert_equal 10, encrypt.indexes[:b]
+  def test_it_can_advance_symbol_index_with_punctuation
+    encrypt = Encryption.new(".....", "02715", "040895")
+    encrypt.encrypt_message
+    assert_equal 8, encrypt.indexes[:a]
+    assert_equal 5, encrypt.indexes[:b]
+    assert_equal 6, encrypt.indexes[:c]
+    assert_equal 7, encrypt.indexes[:d]
+    assert_equal ".....", encrypt.encrypted_message
   end
 
 end

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -104,6 +104,12 @@ class EncryptionTest < Minitest::Test
     assert_equal "keder ohulw!", encrypt.encrypted_message
   end
 
+  def test_it_can_encrypt_text_with_punctuation_in_the_middle
+    encrypt = Encryption.new("Hello, World!", "02715", "040895")
+    encrypt.encrypt_message
+    assert_equal "keder,sprrdx!", encrypt.encrypted_message
+  end
+
   def test_it_can_create_hash_of_alphabet_with_index
     encrypt = Encryption.new("Hello World", "02715", "040895")
     assert_equal ({"a"=>0,"b"=>1,"c"=>2,"d"=>3,"e"=>4,"f"=>5,"g"=>6,"h"=>7,"i"=>8,"j"=>9,"k"=>10,"l"=>11,"m"=>12,"n"=>13,"o"=>14,"p"=>15,"q"=>16,"r"=>17,"s"=>18,"t"=>19,"u"=>20,"v"=>21,"w"=>22,"x"=>23,"y"=>24,"z"=>25," "=>26}), encrypt.alphabet_index
@@ -121,6 +127,12 @@ class EncryptionTest < Minitest::Test
     encrypt.encrypt_letter(0, "c")
     assert_equal "f", encrypt.encrypted_message
     assert_equal ({:a => 4, :b => 1, :c => 2, :d => 3}), encrypt.indexes
+  end
+
+  def test_it_can_advance_symbol_index
+    encrypt = Encryption.new("Hello, World", "02715", "040895")
+    encrypt.advance_symbol_index(6)
+    assert_equal 10, encrypt.indexes[:b]
   end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -37,15 +37,6 @@ class EnigmaTest < Minitest::Test
     assert_equal 6, enigma.date.length
   end
 
-  def test_it_can_encrypt_with_punctuation_between_letters
-    enigma = Enigma.new
-    assert_equal ({
-      encryption: " dy,hqrbt?",
-      key: "80302",
-      date: "040387"
-      }), enigma.encrypt("sup, girl?", "80302", "040387")
-  end
-
   def test_it_can_encrypt_punctuation
     enigma = Enigma.new
     assert_equal ({
@@ -53,6 +44,15 @@ class EnigmaTest < Minitest::Test
       key: "02715",
       date: "040895"
       }), enigma.encrypt("Hello World!", "02715", "040895")
+  end
+
+  def test_it_can_encrypt_with_punctuation_between_letters
+    enigma = Enigma.new
+    assert_equal ({
+      encryption: " dy,hqrbt?",
+      key: "80302",
+      date: "040387"
+      }), enigma.encrypt("sup, girl?", "80302", "040387")
   end
 
   def test_it_can_decrypt
@@ -71,6 +71,15 @@ class EnigmaTest < Minitest::Test
       key: "02715",
       date: "040895"
       }), enigma.decrypt("keder ohulw!", "02715", "040895")
+  end
+
+  def test_it_can_decrypt_with_punctuation_between_letters
+    enigma = Enigma.new
+    assert_equal ({
+      decryption: "sup, girl?",
+      key: "80302",
+      date: "040387"
+      }), enigma.decrypt(" dy,hqrbt?", "80302", "040387")
   end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -40,7 +40,7 @@ class EnigmaTest < Minitest::Test
   def test_it_can_encrypt_with_punctuation_between_letters
     enigma = Enigma.new
     assert_equal ({
-      encryption: " dy,hqrt?",
+      encryption: " dy,hqrbt?",
       key: "80302",
       date: "040387"
       }), enigma.encrypt("sup, girl?", "80302", "040387")

--- a/test/shift_test.rb
+++ b/test/shift_test.rb
@@ -46,4 +46,15 @@ class ShiftTest < Minitest::Test
     assert_equal [3, 27, 73, 20], shift.get_shifts
   end
 
+  def test_it_can_store_shifts
+    shift = Shift.new("Hello World", "02715", "040895")
+    assert_equal [3, 27, 73, 20], shift.shifts
+  end
+
+  def test_it_can_advance_symbol_index
+    shift = Shift.new("Hello World", "02715", "040895")
+    shift.advance_symbol_index(0)
+    assert_equal 4, shift.indexes[:a]
+  end
+
 end


### PR DESCRIPTION
Updated Encryption and Decryption to be advance indexes when punctuation or non-alphabet characters are encountered. This required creating a helper method, which was placed in the shift parent class because it included an instance variable and needed to be accessed by both classes. 
Also added tests to all classes to ensure that the new helper method was tested and that all classes can handle text input with non-alphabet characters in the text. 